### PR TITLE
Use the web site of gitnex

### DIFF
--- a/docs/content/doc/advanced/third-party-tools.en-us.md
+++ b/docs/content/doc/advanced/third-party-tools.en-us.md
@@ -30,7 +30,7 @@ menu:
 
 
 ### Mobile
-[GitNex for Android](https://gitlab.com/mmarif4u/gitnex)
+[GitNex for Android](https://gitnex.com/)
 
 ###  Editor Extensions
  - [Gitea Extension for Visual Studio](https://github.com/maikebing/Gitea.VisualStudio)   Download from   [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=MysticBoy.GiteaExtensionforVisualStudio)


### PR DESCRIPTION
GitNex repo has moved to gitea.com. Let's use the gitnex.com webiste in the doc instead.
